### PR TITLE
Handle consent changes

### DIFF
--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -46,5 +46,4 @@ class SmsController < ApiController
     twilio_request = validator.validate(request.url, request.POST, twilio_signature)
     head :forbidden unless twilio_request
   end
-
 end

--- a/app/controllers/sms_controller.rb
+++ b/app/controllers/sms_controller.rb
@@ -25,7 +25,7 @@ class SmsController < ApiController
   end
 
   def incoming_message
-    SmsMessage.create(
+    sms_message = SmsMessage.create(
       message_sid: params["MessageSid"],
       from: params["From"],
       to: params["To"],
@@ -33,6 +33,13 @@ class SmsController < ApiController
       direction: :inbound,
       status: params["SmsStatus"].downcase
     )
+
+    if opt_in? sms_message.body
+      ConsentChange.create(new_consent: true, change_source: :sms, sms_message: sms_message)
+    elsif opt_out? sms_message.body
+      ConsentChange.create(new_consent: false, change_source: :sms, sms_message: sms_message)
+    end
+
     head :created
   end
 
@@ -44,4 +51,19 @@ class SmsController < ApiController
     twilio_request = validator.validate(request.url, request.POST, twilio_signature)
     head :forbidden unless twilio_request
   end
+
+  def consent_change?(message_body)
+    opt_out?(message_body) or opt_in?(message_body)
+  end
+
+  def opt_out?(message_body)
+    english_opt_out_keywords = %w(STOP STOPALL UNSUBSCRIBE CANCEL END QUIT)
+    spanish_opt_out_keywords = %w(DETENER FIN CANCELAR SUSCRIBIRSE DEJAR ALTO)
+    english_opt_out_keywords.include? message_body or spanish_opt_out_keywords.include? message_body
+  end
+
+  def opt_in?(message_body)
+    %w(START YES UNSTOP).include? message_body
+  end
+
 end

--- a/app/models/consent_change.rb
+++ b/app/models/consent_change.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: consent_changes
+#
+#  id              :bigint           not null, primary key
+#  change_source   :string
+#  new_consent     :boolean
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  sms_messages_id :bigint
+#
+# Indexes
+#
+#  index_consent_changes_on_sms_messages_id  (sms_messages_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (sms_messages_id => sms_messages.id)
+#
+class ConsentChange < ApplicationRecord
+  belongs_to :sms_message
+end

--- a/app/models/consent_change.rb
+++ b/app/models/consent_change.rb
@@ -2,21 +2,24 @@
 #
 # Table name: consent_changes
 #
-#  id              :bigint           not null, primary key
-#  change_source   :string
-#  new_consent     :boolean
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  sms_messages_id :bigint
+#  id             :bigint           not null, primary key
+#  change_source  :string           not null
+#  new_consent    :boolean
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  program_id     :bigint
+#  sms_message_id :bigint
 #
 # Indexes
 #
-#  index_consent_changes_on_sms_messages_id  (sms_messages_id)
+#  index_consent_changes_on_program_id      (program_id)
+#  index_consent_changes_on_sms_message_id  (sms_message_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (sms_messages_id => sms_messages.id)
+#  fk_rails_...  (sms_message_id => sms_messages.id)
 #
 class ConsentChange < ApplicationRecord
   belongs_to :sms_message
+  belongs_to :program
 end

--- a/app/models/message_batch.rb
+++ b/app/models/message_batch.rb
@@ -6,10 +6,12 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  message_template_id :bigint           not null
+#  program_id          :bigint
 #
 # Indexes
 #
 #  index_message_batches_on_message_template_id  (message_template_id)
+#  index_message_batches_on_program_id           (program_id)
 #
 # Foreign Keys
 #
@@ -17,5 +19,6 @@
 #
 class MessageBatch < ApplicationRecord
   belongs_to :message_template
+  belongs_to :program
   has_many :recipients
 end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: programs
+#
+#  id               :bigint           not null, primary key
+#  name             :string           not null
+#  opt_in_keywords  :jsonb            not null
+#  opt_in_response  :jsonb            not null
+#  opt_out_keywords :jsonb            not null
+#  opt_out_response :jsonb            not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+class Program < ApplicationRecord
+  extend Mobility
+  translates :opt_in_response, fallbacks: true
+  translates :opt_out_response, fallbacks: true
+end

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -4,14 +4,13 @@
 #
 #  id                    :bigint           not null, primary key
 #  phone_number          :string           not null
-#  program               :string           not null
 #  sms_api_error_code    :string
 #  sms_api_error_message :string
 #  sms_status            :enum             default("imported"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  message_batch_id      :bigint           not null
-#  program_case_id       :string           not null
+#  message_batch_id      :bigint
+#  program_case_id       :string
 #
 # Indexes
 #
@@ -22,7 +21,8 @@
 #  fk_rails_...  (message_batch_id => message_batches.id)
 #
 class Recipient < ApplicationRecord
-  belongs_to :message_batch
+  belongs_to :message_batch, optional: true
   has_one :sms_message
   validates :phone_number, format: { with: /\A\+1\d{10}\z/, message: "%{value} is not a valid phone number"}
+  validates :program_case_id, presence: true, if: -> { message_batch.present? }
 end

--- a/app/models/sms_message.rb
+++ b/app/models/sms_message.rb
@@ -27,7 +27,7 @@
 #  fk_rails_...  (recipient_id => recipients.id)
 #
 class SmsMessage < ApplicationRecord
-  belongs_to :recipient
+  belongs_to :recipient, optional: true
 
   enum :direction, { inbound: "inbound",
                      outbound_api: "outbound-api",

--- a/app/services/consent_service.rb
+++ b/app/services/consent_service.rb
@@ -3,10 +3,7 @@ class ConsentService
   def process_consent_change(sms_message)
     return unless sms_message.direction == "inbound"
     Program.all.each do |program|
-      Rails.logger.info sms_message.body
-      Rails.logger.info program.opt_in_keywords
       opt_in_languages = consent_change_keyword?(sms_message.body, program.opt_in_keywords)
-      Rails.logger.info "OPT IN LANGS: #{opt_in_languages}"
       opt_out_languages = consent_change_keyword?(sms_message.body, program.opt_out_keywords)
       if !opt_in_languages.empty?
         response = Mobility.with_locale(opt_in_languages.first) { program.opt_in_response }

--- a/app/services/consent_service.rb
+++ b/app/services/consent_service.rb
@@ -1,0 +1,37 @@
+class ConsentService
+
+  def process_consent_change(sms_message)
+    return unless sms_message.direction == "inbound"
+    Program.all.each do |program|
+      Rails.logger.info sms_message.body
+      Rails.logger.info program.opt_in_keywords
+      opt_in_languages = consent_change_keyword?(sms_message.body, program.opt_in_keywords)
+      Rails.logger.info "OPT IN LANGS: #{opt_in_languages}"
+      opt_out_languages = consent_change_keyword?(sms_message.body, program.opt_out_keywords)
+      if !opt_in_languages.empty?
+        response = Mobility.with_locale(opt_in_languages.first) { program.opt_in_response }
+        record_and_respond_to_consent_change_via_sms(true, response, program, sms_message)
+      elsif !opt_out_languages.empty?
+        response = Mobility.with_locale(opt_out_languages.first) { program.opt_out_response }
+        record_and_respond_to_consent_change_via_sms(false, response, program, sms_message)
+      end
+    end
+  end
+
+  private
+
+  def record_and_respond_to_consent_change_via_sms(new_consent, response, program, sms_message)
+    ConsentChange.create(new_consent: new_consent, change_source: "sms", sms_message: sms_message, program: program)
+    recipient = Recipient.create(phone_number: sms_message.from)
+    MessageService.new.send_message(recipient, response)
+  end
+
+  def consent_change_keyword?(text, keywords_by_language)
+    keywords_by_language.keys.select do |language|
+      keywords_by_language[language].any? do |keyword|
+        keyword.casecmp?(text)
+      end
+    end
+  end
+
+end

--- a/app/services/message_batch_import_service.rb
+++ b/app/services/message_batch_import_service.rb
@@ -2,20 +2,24 @@ require 'csv'
 
 class MessageBatchImportService
   MessageTemplateNotFound = Class.new(StandardError)
+  ProgramNotFound = Class.new(StandardError)
   MissingHeaders = Class.new(StandardError)
   InvalidPhoneNumberException = Class.new(StandardError)
 
-  def import_message_batch(message_template_name, recipient_csv)
+  def import_message_batch(message_template_name, program_name, recipient_csv)
     message_template = MessageTemplate.find_by(name: message_template_name)
     raise MessageTemplateNotFound unless message_template
 
-    message_batch = MessageBatch.create(message_template: message_template)
+    program = Program.find_by(name: program_name)
+    raise ProgramNotFound unless program
+
+    message_batch = MessageBatch.create(message_template: message_template, program: program)
 
     created_count = 0
     CSV.foreach(recipient_csv, headers: true, header_converters: :symbol) do |row|
       raise MissingHeaders if [:case_id, :phone_number].difference(row.headers).any?
       phone_number = convert_phone_number(row[:phone_number])
-      Recipient.create(program: 'SNAP', program_case_id: row[:case_id], phone_number: phone_number, message_batch: message_batch)
+      Recipient.create(program_case_id: row[:case_id], phone_number: phone_number, message_batch: message_batch)
       created_count += 1
     end
   end

--- a/db/migrate/20221028001939_create_consent_changes.rb
+++ b/db/migrate/20221028001939_create_consent_changes.rb
@@ -1,0 +1,11 @@
+class CreateConsentChanges < ActiveRecord::Migration[7.0]
+  def change
+    create_table :consent_changes do |t|
+      t.boolean :new_consent
+      t.string :change_source
+      t.references :sms_messages, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221028001939_create_consent_changes.rb
+++ b/db/migrate/20221028001939_create_consent_changes.rb
@@ -2,8 +2,8 @@ class CreateConsentChanges < ActiveRecord::Migration[7.0]
   def change
     create_table :consent_changes do |t|
       t.boolean :new_consent
-      t.string :change_source
-      t.references :sms_messages, foreign_key: true
+      t.string :change_source, null: false
+      t.references :sms_message, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20221106212908_create_programs.rb
+++ b/db/migrate/20221106212908_create_programs.rb
@@ -1,0 +1,17 @@
+class CreatePrograms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :programs do |t|
+      t.string :name, null: false
+      t.jsonb :opt_in_keywords, null: false
+      t.jsonb :opt_out_keywords, null: false
+      t.jsonb :opt_in_response, null: false, default: {}
+      t.jsonb :opt_out_response, null: false, default: {}
+      t.timestamps
+    end
+
+    remove_column :recipients, :program, :string
+
+    add_reference :message_batches, :program
+    add_reference :consent_changes, :program
+  end
+end

--- a/db/migrate/20221110020049_make_recipient_case_id_optional.rb
+++ b/db/migrate/20221110020049_make_recipient_case_id_optional.rb
@@ -1,0 +1,8 @@
+class MakeRecipientCaseIdOptional < ActiveRecord::Migration[7.0]
+  def change
+
+    change_column_null :recipients, :message_batch_id, true
+    change_column_null :recipients, :program_case_id, true
+
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,33 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+# announcements = Program.create!(
+#   name: "ANNOUNCEMENTS",
+#   opt_in_keywords: {en: ["STARTANNOUNCEMENTS"], es: ["STARTANNOUNCEMENTSSPANISH"]},
+#   opt_out_keywords: {en: ["STOPANNOUNCEMENTS"], es: ["ALTOANNOUNCEMENTS"]},
+#   opt_in_response: "Hello",
+#   opt_out_response: "Goodbye"
+# )
+# Mobility.with_locale(:es) do
+#   announcements.opt_in_response = "Hola"
+#   announcements.opt_out_response = "Adios"
+# end
+# announcements.save
+
+snap = Program.create!(
+  name: "SNAP",
+  opt_in_keywords: {
+    en: %w(START UNSTOP STARTSNAP),
+    es: %w(COMENZAR COMENZARSNAP)},
+  opt_out_keywords: {
+    en: %w(STOP END CANCEL UNSUBSCRIBE QUIT STOPSNAP),
+    es: %w(DETENER FIN CANCELAR SUSCRIBIRSE DEJAR ALTOSNAP)},
+  opt_in_response: "Hello",
+  opt_out_response: "You have successfully unsubscribed from DSS reminders. You will not receive any more messages from this number. Reply START to resubscribe."
+)
+Mobility.with_locale(:es) do
+  snap.opt_in_response = "Hola"
+  snap.opt_out_response = "Se ha dado de baja de recibir recordatorios de DSS. No recibirá más mensajes de este número. Responda COMENZAR para reinscribirse."
+end
+snap.save

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,19 +19,21 @@
 # end
 # announcements.save
 
-snap = Program.create!(
+snap = Program.new(
   name: "SNAP",
   opt_in_keywords: {
     en: %w(START UNSTOP STARTSNAP),
     es: %w(COMENZAR COMENZARSNAP)},
   opt_out_keywords: {
     en: %w(STOP END CANCEL UNSUBSCRIBE QUIT STOPSNAP),
-    es: %w(DETENER FIN CANCELAR SUSCRIBIRSE DEJAR ALTOSNAP)},
-  opt_in_response: "Hello",
-  opt_out_response: "You have successfully unsubscribed from DSS reminders. You will not receive any more messages from this number. Reply START to resubscribe."
+    es: %w(DETENER FIN CANCELAR SUSCRIBIRSE DEJAR ALTOSNAP)}
 )
+Mobility.with_locale(:en) do
+  snap.opt_in_response = "Hello"
+  snap.opt_out_response = "You have successfully unsubscribed from DSS reminders. You will not receive any more messages from this number. Reply START to resubscribe."
+end
 Mobility.with_locale(:es) do
   snap.opt_in_response = "Hola"
   snap.opt_out_response = "Se ha dado de baja de recibir recordatorios de DSS. No recibirá más mensajes de este número. Responda COMENZAR para reinscribirse."
 end
-snap.save
+snap.save!

--- a/spec/factories/programs.rb
+++ b/spec/factories/programs.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: programs
+#
+#  id               :bigint           not null, primary key
+#  name             :string           not null
+#  opt_in_keywords  :jsonb            not null
+#  opt_in_response  :jsonb            not null
+#  opt_out_keywords :jsonb            not null
+#  opt_out_response :jsonb            not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+FactoryBot.define do
+  factory :program do
+    name { "SNAP" }
+    opt_in_keywords { {en: ["STARTTEST"], es: ["STARTTESTSPANISH"]} }
+    opt_out_keywords { {en: ["STOPTEST"], es: ["STOPTESTSPANISH"]} }
+    opt_in_response { "HelloTest" }
+    opt_out_response { "GoodbyeTest" }
+  end
+end

--- a/spec/factories/sms_messages.rb
+++ b/spec/factories/sms_messages.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: sms_messages
+#
+#  id            :bigint           not null, primary key
+#  body          :text
+#  date_created  :datetime
+#  date_sent     :datetime
+#  date_updated  :datetime
+#  direction     :enum             not null
+#  error_code    :string
+#  error_message :string
+#  from          :string
+#  message_sid   :string
+#  status        :enum             not null
+#  to            :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  recipient_id  :bigint
+#
+# Indexes
+#
+#  index_sms_messages_on_recipient_id  (recipient_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (recipient_id => recipients.id)
+#
+FactoryBot.define do
+  factory :sms_message do
+    body { 'message body' }
+    direction { :inbound }
+    status { :delivered }
+  end
+end

--- a/spec/models/consent_change_spec.rb
+++ b/spec/models/consent_change_spec.rb
@@ -2,20 +2,22 @@
 #
 # Table name: consent_changes
 #
-#  id              :bigint           not null, primary key
-#  change_source   :string
-#  new_consent     :boolean
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  sms_messages_id :bigint
+#  id             :bigint           not null, primary key
+#  change_source  :string           not null
+#  new_consent    :boolean
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  program_id     :bigint
+#  sms_message_id :bigint
 #
 # Indexes
 #
-#  index_consent_changes_on_sms_messages_id  (sms_messages_id)
+#  index_consent_changes_on_program_id      (program_id)
+#  index_consent_changes_on_sms_message_id  (sms_message_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (sms_messages_id => sms_messages.id)
+#  fk_rails_...  (sms_message_id => sms_messages.id)
 #
 require 'rails_helper'
 

--- a/spec/models/consent_change_spec.rb
+++ b/spec/models/consent_change_spec.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: consent_changes
+#
+#  id              :bigint           not null, primary key
+#  change_source   :string
+#  new_consent     :boolean
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  sms_messages_id :bigint
+#
+# Indexes
+#
+#  index_consent_changes_on_sms_messages_id  (sms_messages_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (sms_messages_id => sms_messages.id)
+#
+require 'rails_helper'
+
+RSpec.describe ConsentChange, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/message_batch_spec.rb
+++ b/spec/models/message_batch_spec.rb
@@ -6,10 +6,12 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  message_template_id :bigint           not null
+#  program_id          :bigint
 #
 # Indexes
 #
 #  index_message_batches_on_message_template_id  (message_template_id)
+#  index_message_batches_on_program_id           (program_id)
 #
 # Foreign Keys
 #

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: programs
+#
+#  id               :bigint           not null, primary key
+#  name             :string           not null
+#  opt_in_keywords  :jsonb            not null
+#  opt_in_response  :jsonb            not null
+#  opt_out_keywords :jsonb            not null
+#  opt_out_response :jsonb            not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+require 'rails_helper'
+
+RSpec.describe Program, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/recipient_spec.rb
+++ b/spec/models/recipient_spec.rb
@@ -4,14 +4,13 @@
 #
 #  id                    :bigint           not null, primary key
 #  phone_number          :string           not null
-#  program               :string           not null
 #  sms_api_error_code    :string
 #  sms_api_error_message :string
 #  sms_status            :enum             default("imported"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  message_batch_id      :bigint           not null
-#  program_case_id       :string           not null
+#  message_batch_id      :bigint
+#  program_case_id       :string
 #
 # Indexes
 #

--- a/spec/services/consent_service_spec.rb
+++ b/spec/services/consent_service_spec.rb
@@ -1,0 +1,172 @@
+require 'rails_helper'
+
+describe ConsentService do
+
+  let(:program) { create(:program) }
+
+  describe "#process_consent_change" do
+    context "When the message does not contain an opt-in or opt-out keyword" do
+      let(:sms_message) { build(
+        :sms_message,
+        body: "Hello!",
+        direction: :inbound
+      ) }
+      specify {
+        expect {
+          described_class.new.process_consent_change(sms_message)
+        }.to_not change { ConsentChange.count }
+      }
+    end
+
+    context "When the message is an english opt-in keyword" do
+      let(:sms_message) { build(
+          :sms_message,
+          body: "STARTTEST",
+          direction: :inbound
+        )
+      }
+      specify {
+        expect_any_instance_of(MessageService)
+          .to receive(:send_message).with(
+            anything,
+            Mobility.with_locale(:en) { program.opt_in_response }
+          )
+        expect {
+          described_class.new.process_consent_change(sms_message)
+        }.to change { ConsentChange.count }.from(0).to(1)
+        expect(ConsentChange.last)
+          .to have_attributes(
+                new_consent: true,
+                sms_message: sms_message,
+                program: program
+              )
+      }
+    end
+
+    context "When the message is an english opt-out keyword" do
+      let(:sms_message) { build(
+        :sms_message,
+        body: "STOPTEST",
+        direction: :inbound
+      ) }
+      specify {
+        expect_any_instance_of(MessageService)
+          .to receive(:send_message).with(
+            anything,
+            Mobility.with_locale(:en) { program.opt_out_response }
+          )
+        expect {
+          described_class.new.process_consent_change(sms_message)
+        }.to change { ConsentChange.count }.from(0).to(1)
+        expect(ConsentChange.last)
+          .to have_attributes(
+                new_consent: false,
+                sms_message: sms_message,
+                program: program
+              )
+      }
+    end
+
+    context "When the message is a keyword with mixed case" do
+      let(:sms_message) { build(
+        :sms_message,
+        body: "sToPtEsT",
+        direction: :inbound
+      ) }
+      specify {
+        expect_any_instance_of(MessageService)
+          .to receive(:send_message).with(
+            anything,
+            Mobility.with_locale(:en) { program.opt_out_response }
+          )
+        expect {
+          described_class.new.process_consent_change(sms_message)
+        }.to change { ConsentChange.count }.from(0).to(1)
+        expect(ConsentChange.last)
+          .to have_attributes(
+                new_consent: false,
+                sms_message: sms_message,
+                program: program
+              )
+      }
+    end
+
+    context "When the message contains a keyword and additional text" do
+      let(:sms_message) { build(
+        :sms_message,
+        body: "stoptest please",
+        direction: :inbound
+      ) }
+      specify {
+        expect {
+          described_class.new.process_consent_change(sms_message)
+        }.to_not change { ConsentChange.count }
+      }
+    end
+
+    context "When the message is a spanish opt-out keyword" do
+      before {
+        Mobility.with_locale(:es) { program.opt_out_response = "Adios" }
+        program.save
+      }
+
+      let(:sms_message) { build(
+        :sms_message,
+        body: "STOPTESTSPANISH",
+        direction: :inbound
+      ) }
+
+      specify {
+        expect_any_instance_of(MessageService)
+          .to receive(:send_message).with(
+            anything,
+            Mobility.with_locale(:es) { program.opt_out_response }
+          )
+        expect {
+          described_class.new.process_consent_change(sms_message)
+        }.to change { ConsentChange.count }.from(0).to(1)
+        expect(ConsentChange.last)
+          .to have_attributes(
+                new_consent: false,
+                sms_message: sms_message,
+                program: program
+              )
+      }
+    end
+
+    context "When there are multiple programs" do
+      let(:wic) { create(
+        :program,
+        name: "WIC",
+        opt_in_keywords: {en: ["STARTWIC"], es: ["STARTWICSPANISH"]},
+        opt_out_keywords: {en: ["STOPWIC"], es: ["STOPWICSPANISH"]},
+        opt_in_response: "Hello from WIC!",
+        opt_out_response: "Goodbye from WIC!"
+      ) }
+
+      let(:sms_message) { build(
+        :sms_message,
+        body: "STOPWIC",
+        direction: :inbound
+      ) }
+      specify {
+        expect_any_instance_of(MessageService)
+          .to receive(:send_message).with(
+            anything,
+            Mobility.with_locale(:en) { wic.opt_out_response }
+          )
+        expect {
+          described_class.new.process_consent_change(sms_message)
+        }.to change { ConsentChange.count }.from(0).to(1)
+        expect(ConsentChange.last)
+          .to have_attributes(
+                new_consent: false,
+                sms_message: sms_message,
+                program: wic
+              )
+      }
+    end
+
+  end
+
+end

--- a/spec/services/message_batch_import_service_spec.rb
+++ b/spec/services/message_batch_import_service_spec.rb
@@ -3,23 +3,28 @@ require 'rails_helper'
 describe MessageBatchImportService do
 
   let(:message_template) { MessageTemplate.create(name: 'NotifyMessage', body: 'Notify message body') }
+  let(:program) { create(:program) }
 
   describe "#import_message_batch" do
     context "when the message_template cannot be found" do
-      specify { expect { described_class.new.import_message_batch('non_existent_message_template', 'some_recipients.csv') }.to raise_error(MessageBatchImportService::MessageTemplateNotFound) }
+      specify { expect { described_class.new.import_message_batch('non_existent_message_template', program.name, 'some_recipients.csv') }.to raise_error(MessageBatchImportService::MessageTemplateNotFound) }
+    end
+
+    context "when the program cannot be found" do
+      specify { expect { described_class.new.import_message_batch(message_template.name, 'NO PROGRAM', 'some_recipients.csv') }.to raise_error(MessageBatchImportService::ProgramNotFound) }
     end
 
     context "when the recipients CSV is not a valid file" do
-      specify { expect { described_class.new.import_message_batch(message_template.name, 'some_recipients.csv') }.to raise_error(SystemCallError) }
+      specify { expect { described_class.new.import_message_batch(message_template.name, program.name, 'some_recipients.csv') }.to raise_error(SystemCallError) }
     end
 
     context "when the CSV has incorrect headers" do
-      specify { expect { described_class.new.import_message_batch(message_template.name, file_fixture('recipients_bad_headers.csv')) }.to raise_error(MessageBatchImportService::MissingHeaders) }
+      specify { expect { described_class.new.import_message_batch(message_template.name, program.name, file_fixture('recipients_bad_headers.csv')) }.to raise_error(MessageBatchImportService::MissingHeaders) }
     end
 
     context "when on the happy path" do
       it "creates a MessageBatch" do
-        expect { described_class.new.import_message_batch(message_template.name, file_fixture('good_recipients.csv')) }
+        expect { described_class.new.import_message_batch(message_template.name, program.name, file_fixture('good_recipients.csv')) }
           .to change(MessageBatch, :count).from(0).to(1)
           .and change(Recipient, :count).from(0).to(2)
       end


### PR DESCRIPTION
Add a Program model which stores opt-in/out keywords and responses in multiple languages, a ConsentChange model which records consent changes resulting from inbound texts, and a service class to process texts to identify and handle consent changes

Story ID #183621330